### PR TITLE
URL health checker feature

### DIFF
--- a/app/Console/Commands/HealthCheckerCommand.php
+++ b/app/Console/Commands/HealthCheckerCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+use Airtable;
+use App\Jobs\HealthChecker;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class HealthCheckerCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'health-checker';
+
+    /**
+     * Retrieves the Airtable records and dispatch the job of checking the url status to a queue.
+     *
+     * @var string
+     */
+    protected $description = 'Retrieves the Airtable records and dispatch the job of checking the url status to a queue';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $allListings = Airtable::table('listings')->all();
+        Log::channel('healthcheck')->info("HEALTH CHECKER START");
+        foreach ($allListings as $record){
+            HealthChecker::dispatch($record);
+        }
+        return 0;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -35,6 +35,10 @@ class Kernel extends ConsoleKernel
             ->dailyAt('2:45')
             ->timezone('America/New_York');
 
+        $schedule->command('health-checker')
+            ->weekly()
+            ->timezone('America/New_York');
+
     }
 
     /**

--- a/app/Http/Controllers/Airtable/Sync/LocationController.php
+++ b/app/Http/Controllers/Airtable/Sync/LocationController.php
@@ -42,6 +42,10 @@ class LocationController extends Controller {
                 $country = "United Kingdom";
             }
 
+            if ($country == "SA" || $country == "South Africa") {
+                $country = "South Africa";
+            }
+
             $ct = Country::where('country', $country)->first();
             if ($ct) {
                 $loc->update([

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -24,9 +24,71 @@ use Carbon\Carbon;
 class TestController extends Controller {
 
     public function test(Request $request) {
-        $tags = Airtable::table('tags')->get();
+        $dbLocations = Location::get();
+        /*$key = config('services.google.key');
 
-        print_r($tags);
+        foreach($dbLocations as $loc) {
+            if (!empty($loc->name)) {
+                $pieces = explode(' ', $loc->name);
+
+                $length = sizeof($pieces);
+
+                if ($length >= 2) {
+                    $address = $pieces[$length-2].", ".$pieces[$length-1];
+                    echo "Address : ".$address."<br>";
+                    $address = urlencode($loc->name);
+                    
+                    
+                    $geocode = file_get_contents('https://maps.googleapis.com/maps/api/geocode/json?key='.$key.'&address='.$address.'&sensor=false');
+
+                    $data = @json_decode($geocode);
+                    $add_array  = @$data->results;
+                    $add_array = @$add_array[0];
+                    $add_array = @$add_array->address_components;
+                    $country = "";
+                    foreach ($add_array as $key) {
+                      if($key->types[0] == 'country'){
+                        $country = @$key->long_name;
+                      }
+                    }
+                    
+                    echo "Country : ".$country;
+                    echo "<br>";
+                }
+
+                
+            }
+            
+        }*/
+        
+
+
+        foreach($dbLocations as $loc) {
+            $pieces = explode(' ', $loc->name);
+            //$country = array_pop($pieces);
+
+            $length = sizeof($pieces);
+
+            if ($length >= 2) {
+                $country = $pieces[$length-2]." ".$pieces[$length-1];
+            }
+            
+            //echo $country."<br>";
+
+            if ($country == "SA" || $country == "South Africa") {
+                $country = "South Africa";
+            }
+
+            $ct = Country::where('country', $country)->first();
+            if ($ct) {
+                $loc->update([
+                    'country' => $ct->country
+                ]);
+            }
+        }
+
+        echo "Done";
+
 
         /*$listings = Airtable::table('listings')->all();
 

--- a/app/Jobs/HealthChecker.php
+++ b/app/Jobs/HealthChecker.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Airtable;
+
+class HealthChecker implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 5;
+    public $record;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($record)
+    {
+        $this->record = $record;
+    }
+
+    /**
+     * Execute the job.
+     * Check the url status: do nothing if success,
+     * try to fix if broken, log if not able to fix
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $url = $this->record['fields']['Website URL'] ?? false;
+        $statusCheck = $url ? $this->statusCheck($url) : false;
+        if ($this->isSuccessfulStatus($statusCheck)) {
+            return;
+        }
+
+        if ($this->isBrokenStatus($statusCheck)) {
+            $newUrl = $this->findWaybackLink($url);
+            if($newUrl){
+                Log::channel('healthcheck')->info("FIXED RECORD ID: {$this->record['id']} WEBSITE URL: {$newUrl}");
+                $this->updateAirtableRecord($this->record, $newUrl);
+                return;
+            }
+        }
+
+        $this->logToCheckManually($this->record, $statusCheck);
+    }
+
+    /**
+     * Gets the status of a given url request
+     *
+     * @param string $url
+     *
+     * @return int
+     */
+    public function statusCheck($url)
+    {
+        try {
+            $response = Http::get($url);
+            return $response->status();
+        }catch (\Exception $exception){
+            Log::channel('healthcheck')->info("MANUAL CHECK URL: {$url} EXCEPTION: {$exception->getMessage()}");
+            return 400;
+        }
+    }
+
+    /**
+     * @param $statusCheck
+     *
+     * @return bool
+     */
+    public function isSuccessfulStatus($statusCheck)
+    {
+        return $statusCheck >= 200 && $statusCheck < 300;
+    }
+
+    /**
+     * @param $statusCheck
+     *
+     * @return bool
+     */
+    public function isBrokenStatus($statusCheck)
+    {
+        return $statusCheck >= 400;
+    }
+    /**
+     * Find the latest archived for a given url
+     *
+     * @param string $urlToFind
+     *
+     * @return null
+     */
+    public function findWaybackLink(string $urlToFind)
+    {
+        try {
+            $waybackLink = 'http://archive.org/wayback/available?url='. $urlToFind;
+            $jsonResponse = Http::get($waybackLink);
+            $responseObject = json_decode($jsonResponse);
+            $hasClosestLink = !empty($responseObject->archived_snapshots);
+            $newUrl = null;
+            if($hasClosestLink){
+                $newUrl = $responseObject->archived_snapshots->closest->url;
+            }
+
+            return $newUrl;
+        }catch (\Exception $exception){
+            return null;
+        }
+    }
+
+    /**
+     * Update the listing record in Airtable
+     *
+     * @param $record
+     * @param $newUrl
+     */
+    public function updateAirtableRecord( $record, $newUrl)
+    {
+        Airtable::table('listings')->patch($record['id'],["Website URL"=>$newUrl]);
+    }
+
+    /**
+     * Logs the data of the failed record in a log file
+     *
+     * @param $record
+     * @param int $status
+     */
+    public function logToCheckManually($record, $status)
+    {
+        $url = $this->record['fields']['Website URL'] ?? 'NO URL PROVIDED';
+        Log::channel('healthcheck')->info("MANUAL CHECK ID: {$record['id']} WEBSITE URL: {$url} RECEIVED STATUS: {$status}");
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -99,6 +99,12 @@ return [
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
         ],
+
+        'healthcheck' => [
+            'driver' => 'single',
+            'level'  => 'info',
+            'path'   => storage_path('logs/healthcheck.log'),
+        ],
     ],
 
 ];

--- a/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
+++ b/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFailedJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('failed_jobs');
+    }
+};

--- a/database/migrations/2022_05_07_151151_create_jobs_table.php
+++ b/database/migrations/2022_05_07_151151_create_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('jobs');
+    }
+};

--- a/tests/Jobs/HealthCheckerTest.php
+++ b/tests/Jobs/HealthCheckerTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Tests\Jobs;
+
+use App\Jobs\HealthChecker;
+use Tests\TestCase;
+
+class HealthCheckerTest extends TestCase
+{
+    private $record = [
+        'id' => 'id',
+        'fields' => [
+            'Website URL' => "https://civictech.guide"
+        ]
+    ];
+
+    /**
+     * Test that a given url is available.
+     *
+     * @test
+     */
+    public function handlesSuccess()
+    {
+        $testee = $this->getMockBuilder(HealthChecker::class)
+            ->setConstructorArgs([$this->record])->onlyMethods(
+            [
+                'statusCheck',
+                'isBrokenStatus',
+                'updateAirtableRecord',
+                'logToCheckManually'
+            ]
+        )->getMock();
+
+        $testee->expects($this->once())->method('statusCheck')->willReturn(200);
+        $testee->expects($this->never())->method('isBrokenStatus');
+        $testee->expects($this->never())->method('updateAirtableRecord');
+        $testee->expects($this->never())->method('logToCheckManually');
+        $testee->handle();
+    }
+
+    /**
+     * Test that a given url is no longer available.
+     *
+     * @test
+     */
+    public function handlesFailureNoURLProvided()
+    {
+        $record = [
+            'id'=>'id',
+            'fields' => [
+                'Website URL' => ""
+            ]
+        ];
+        $testee = $this->getMockBuilder(HealthChecker::class)
+            ->setConstructorArgs([$record])->onlyMethods(
+            [
+                'statusCheck',
+                'isSuccessfulStatus',
+                'isBrokenStatus',
+                'updateAirtableRecord',
+                'logToCheckManually'
+            ]
+        )->getMock();
+
+        $testee->expects($this->never())->method('statusCheck')->willReturn(
+            false
+        );
+        $testee->expects($this->once())->method('isSuccessfulStatus')->willReturn(
+            false
+        );
+        $testee->expects($this->once())->method('isBrokenStatus')->willReturn(
+            false
+        );
+        $testee->expects($this->never())->method('updateAirtableRecord');
+        $testee->expects($this->once())->method('logToCheckManually');
+        $testee->handle();
+    }
+
+    /**
+     * Test that a given url is no longer available and fixes.
+     *
+     * @test
+     */
+    public function handlesFailure400AndFixes()
+    {
+        $testee = $this->getMockBuilder(HealthChecker::class)
+            ->setConstructorArgs([$this->record])->onlyMethods(
+            [
+                'statusCheck',
+                'isSuccessfulStatus',
+                'isBrokenStatus',
+                'updateAirtableRecord',
+                'findWaybackLink',
+                'logToCheckManually'
+            ]
+        )->getMock();
+
+        $testee->expects($this->once())->method('statusCheck')->willReturn(400);
+        $testee->expects($this->once())->method('isSuccessfulStatus')->willReturn(
+            false
+        );
+        $testee->expects($this->once())->method('isBrokenStatus')->willReturn(
+            true
+        );
+        $testee->expects($this->once())->method('findWaybackLink')->willReturn(
+            "archive:https://civictech.guide"
+        );
+        $testee->expects($this->once())->method('updateAirtableRecord');
+        $testee->expects($this->never())->method('logToCheckManually');
+        $testee->handle();
+    }
+
+    /**
+     * Test that a given url is no longer available and logs.
+     *
+     * @test
+     */
+    public function handlesFailure400AndLogs()
+    {
+        $testee = $this->getMockBuilder(HealthChecker::class)
+            ->setConstructorArgs([$this->record])->onlyMethods(
+            [
+                'statusCheck',
+                'isSuccessfulStatus',
+                'isBrokenStatus',
+                'updateAirtableRecord',
+                'findWaybackLink',
+                'logToCheckManually'
+            ]
+        )->getMock();
+
+        $testee->expects($this->once())->method('statusCheck')->willReturn(400);
+        $testee->expects($this->once())->method('isSuccessfulStatus')->willReturn(
+            false
+        );
+        $testee->expects($this->once())->method('isBrokenStatus')->willReturn(
+            true
+        );
+        $testee->expects($this->once())->method('findWaybackLink')->willReturn(
+            null
+        );
+        $testee->expects($this->never())->method('updateAirtableRecord');
+        $testee->expects($this->once())->method('logToCheckManually');
+        $testee->handle();
+    }
+
+    /**
+     * Test that a given url is no longer available.
+     *
+     * @test
+     */
+    public function handlesFailure300AndLogs()
+    {
+        $testee = $this->getMockBuilder(HealthChecker::class)
+            ->setConstructorArgs([$this->record])->onlyMethods(
+            [
+                'statusCheck',
+                'isSuccessfulStatus',
+                'isBrokenStatus',
+                'updateAirtableRecord',
+                'findWaybackLink',
+                'logToCheckManually'
+            ]
+        )->getMock();
+
+        $testee->expects($this->once())->method('statusCheck')->willReturn(400);
+        $testee->expects($this->once())->method('isSuccessfulStatus')->willReturn(
+            false
+        );
+        $testee->expects($this->once())->method('isBrokenStatus')->willReturn(
+            true
+        );
+        $testee->expects($this->once())->method('findWaybackLink')->willReturn(
+            null
+        );
+        $testee->expects($this->never())->method('updateAirtableRecord');
+        $testee->expects($this->once())->method('logToCheckManually');
+        $testee->handle();
+    }
+
+    /**
+     * Test that will return the archived url if the site exists.
+     *
+     * @test
+     */
+    public function findWaybackLink()
+    {
+        $record = [
+            'fields' => [
+                'Website URL' => "http://google.com"
+            ]
+        ];
+        $testee = new HealthChecker($record);
+        $expectedLink = 'http://web.archive.org/web/';
+
+        self::assertStringStartsWith(
+            $expectedLink,
+            $testee->findWaybackLink(
+                $record['fields']['Website URL']
+            )
+        );
+    }
+
+    /**
+     * Test that will return null if there is no archived site.
+     *
+     * @test
+     */
+    public function noWaybackLink()
+    {
+        $record = [
+            'fields' => [
+                'Website URL' => "http://this_does_not_exist.com"
+            ]
+        ];
+        $testee = new HealthChecker($record);
+        $expectedLink = null;
+
+        self::assertEquals(
+            $expectedLink,
+            $testee->findWaybackLink(
+                $record['fields']['Website URL']
+            )
+        );
+    }
+}


### PR DESCRIPTION
**Motives**
---
This PR intends to provide functionality that retrieves the [Airtable](https://airtable.com) records and checks the availability of the Website URL field. 

The job checks for the request status code and:
- We return if it is successful. 
- If the status is above 400 or we get any other error, try to fix it by retrieving [an archive URL](https://web.archive.org). 
- If we have a redirection, we cannot be sure that it leads to an undesired place, so we log the URL for manual inspection. 
- We log it for manual inspection also if we cannot retrieve the archived URL. 

A new weekly scheduled 'health-checker' command retrieves all the Airtable records and then dispatch one by one to a database queue job so it can run in the background. 
A new channel, 'healthcheck' is dedicated for these logs that will write to a file `logs/healthcheck.log` in the storage folder.

**How to test**
---
Add the `AIRTABLE_KEY` and `AIRTABLE_BASE` credentials for the database (staging/live) you want to test to the .env file.

**NOTE: This feature's goal is to update the Website URL without saving the corrupt one.** 

Then run the command:
 `php artisan health-check`

The Laravel table `CreateJobsTable` will be populated with the queue of remaining jobs. The logs will show what was fixed and what needs attention. 
